### PR TITLE
Laser + light direction and dryfire recoil fixes

### DIFF
--- a/VR Recoil/fpcameraplayerbase.lua
+++ b/VR Recoil/fpcameraplayerbase.lua
@@ -27,23 +27,21 @@ function FPCameraPlayerBase:start_shooting()
 	self._recoil_kick_akimbo.h.current = self._recoil_kick_akimbo.h.current and self._recoil_kick_akimbo.h.current or self._recoil_kick_akimbo.h.accumulated or 0
 end
 
-local cam_stop_shooting_orig = FPCameraPlayerBase.stop_shooting
-function FPCameraPlayerBase:stop_shooting(wait)
-
-    if not VRRecoil.FiredWeaponIsAkimbo then
-        return cam_stop_shooting_orig(self, wait)
-    end
-
-	self._recoil_kick_akimbo.to_reduce = self._recoil_kick_akimbo.accumulated
-	self._recoil_kick_akimbo.h.to_reduce = self._recoil_kick_akimbo.h.accumulated
-	self._recoil_wait_akimbo = wait or 0
-end
-
 function FPCameraPlayerBase:stop_shooting_akimbo(wait)
 	self._recoil_kick_akimbo.to_reduce = self._recoil_kick_akimbo.accumulated
 	self._recoil_kick_akimbo.h.to_reduce = self._recoil_kick_akimbo.h.accumulated
 	self._recoil_wait_akimbo = wait or 0
 end
+
+-- local cam_stop_shooting_orig = FPCameraPlayerBase.stop_shooting
+-- function FPCameraPlayerBase:stop_shooting(wait)
+
+--     if not VRRecoil.FiredWeaponIsAkimbo then
+--         return cam_stop_shooting_orig(self, wait)
+--     end
+
+-- 	self.stop_shooting_akimbo(wait)
+-- end
 
 local cam_break_recoil_orig = FPCameraPlayerBase.break_recoil
 function FPCameraPlayerBase:break_recoil()

--- a/VR Recoil/fpcameraplayerbase.lua
+++ b/VR Recoil/fpcameraplayerbase.lua
@@ -27,7 +27,6 @@ function FPCameraPlayerBase:start_shooting()
 	self._recoil_kick_akimbo.h.current = self._recoil_kick_akimbo.h.current and self._recoil_kick_akimbo.h.current or self._recoil_kick_akimbo.h.accumulated or 0
 end
 
---[[
 local cam_stop_shooting_orig = FPCameraPlayerBase.stop_shooting
 function FPCameraPlayerBase:stop_shooting(wait)
 
@@ -39,7 +38,6 @@ function FPCameraPlayerBase:stop_shooting(wait)
 	self._recoil_kick_akimbo.h.to_reduce = self._recoil_kick_akimbo.h.accumulated
 	self._recoil_wait_akimbo = wait or 0
 end
-]]
 
 function FPCameraPlayerBase:stop_shooting_akimbo(wait)
 	self._recoil_kick_akimbo.to_reduce = self._recoil_kick_akimbo.accumulated

--- a/VR Recoil/playerhandstateweapon.lua
+++ b/VR Recoil/playerhandstateweapon.lua
@@ -67,6 +67,9 @@ function PlayerHandStateWeapon:update(t, dt)
 	
 	mrotation.set_yaw_pitch_roll(weaponRotation, weaponYaw + horizontalKick, weaponPitch + verticalKick, weaponRoll)
 	self._weapon_unit:set_rotation(weaponRotation)
+
+	-- Set the gadget rotation as well, otherwise for example the laser stays pointing in the original direction
+	self._weapon_unit:base():set_gadget_rotation(weaponRotation)
 	
 	return result
 end

--- a/VR Recoil/playerstandardvr.lua
+++ b/VR Recoil/playerstandardvr.lua
@@ -5,15 +5,15 @@ function PlayerStandardVR:_check_fire_per_weapon(t, pressed, held, released, wea
     -- This global variable checks which weapon is currently being fired/evaluated
     VRRecoil.FiredWeaponIsAkimbo = akimbo and true or false
 
-    -- If the weapon is released then reset the recoil
-    -- This works around a bug where firing both akimbos at the same time can result in the left gun getting stuck
-    if released or (weap_base:out_of_ammo() or self:_is_reloading()) then
-        if akimbo then
-            self._camera_unit:base():stop_shooting_akimbo(self._equipped_unit:base():recoil_wait())
-        else
-            self._camera_unit:base():stop_shooting(self._equipped_unit:base():recoil_wait())
-        end
-    end
+    -- -- If the weapon is released then reset the recoil
+    -- -- This works around a bug where firing both akimbos at the same time can result in the left gun getting stuck
+    -- if released or (weap_base:out_of_ammo() or self:_is_reloading()) then
+    --     if akimbo then
+    --         self._camera_unit:base():stop_shooting_akimbo(self._equipped_unit:base():recoil_wait())
+    --     -- else
+    --     --     self._camera_unit:base():stop_shooting(self._equipped_unit:base():recoil_wait())
+    --     end
+    -- end
 
     return playerstandardvr_check_fire_orig(self, t, pressed, held, released, weap_base, akimbo)
 end

--- a/VR Recoil/playerstandardvr.lua
+++ b/VR Recoil/playerstandardvr.lua
@@ -5,15 +5,15 @@ function PlayerStandardVR:_check_fire_per_weapon(t, pressed, held, released, wea
     -- This global variable checks which weapon is currently being fired/evaluated
     VRRecoil.FiredWeaponIsAkimbo = akimbo and true or false
 
-    -- -- If the weapon is released then reset the recoil
-    -- -- This works around a bug where firing both akimbos at the same time can result in the left gun getting stuck
-    -- if released or (weap_base:out_of_ammo() or self:_is_reloading()) then
-    --     if akimbo then
-    --         self._camera_unit:base():stop_shooting_akimbo(self._equipped_unit:base():recoil_wait())
-    --     -- else
-    --     --     self._camera_unit:base():stop_shooting(self._equipped_unit:base():recoil_wait())
-    --     end
-    -- end
+    -- If the trigger is released or the mag empties from shooting (checking before actual update), reset its recoil
+    -- This works around a bug where firing both akimbos at the same time can result in the other gun getting stuck
+    if (released or (weap_base.clip_empty and weap_base:clip_empty())) and self._shooting then
+        if akimbo then
+            self._camera_unit:base():stop_shooting_akimbo(self._equipped_unit:base():recoil_wait())
+        else
+            self._camera_unit:base():stop_shooting(self._equipped_unit:base():recoil_wait())
+        end
+    end
 
     return playerstandardvr_check_fire_orig(self, t, pressed, held, released, weap_base, akimbo)
 end
@@ -42,7 +42,6 @@ function PlayerStandardVR:_check_stop_shooting()
 
 	if self._shooting and self._shooting_weapons then
         for k, weap_base in pairs(self._shooting_weapons) do
-            
             if k == 1 then
                 self._camera_unit:base():stop_shooting(self._equipped_unit:base():recoil_wait())
             elseif k == 2 then


### PR DESCRIPTION
**Fixes for issues:**
- When recoil is applied to a weapon, its laser stays pointing in the original direction
  > Fixed by applying the rotation to the gadget as well, identical to how the game itself does it with every rotational transform to the weapon already
- When the weapon's magazine is empty and user attempts to shoot (dryfire), the accumulated recoil is applied
  > Fixed generally by changing the conditions for the per-weapon release check, to apply only when it was actually shot before and was either released or ran out of ammo.

**Notes:**
- Not exhaustively tested, just with a few select weapons including akimbos, but I'll make sure to post an update if I run across an issue.